### PR TITLE
Pingtrip/add cmdline options

### DIFF
--- a/file2pcap.c
+++ b/file2pcap.c
@@ -92,10 +92,10 @@ void usage() {
 				"\t\t\t-p 1234:80 will simulate a connection from port 1234 to port 80\n"
 				"\t\t\t[default: use IANA assigned port for the protocol]\n\n"
 				"-6\t\t\tUse IPv6 instead of the default IPv4\n"\
-				"-D, --dstip IP\t\tspecify destination IP address\n"
-				"-S, --srcip IP\t\tspecify source IP address\n"
-				"-d, --dstemail email_address\t\tspecify the recipient's email address\n"
-				"-s, --srcemail email_address\t\tspecify the sender's email address\n";				
+				"-d, --dstip IP\t\tspecify destination IP address\n"
+				"-s, --srcip IP\t\tspecify source IP address\n"
+				"-D, --dstemail email_address\t\tspecify the recipient's email address\n"
+				"-S, --srcemail email_address\t\tspecify the sender's email address\n";				
 				
 	char *usage = 		"\nUsage:\n"\
 				"\t\t\tfile2pcap [options] infile\n";
@@ -103,7 +103,8 @@ void usage() {
 				"\t\t\tfile2pcap malware.pdf\n"\
 				"\t\t\tfile2pcap -mshp malware.pdf\n"\
 				"\t\t\tfile2pcap -mH -p8080 malware.pdf\n"\
-				"\t\t\tfile2pcap -mi malware.pdf -o outfile.pcap\n";
+				"\t\t\tfile2pcap -mi malware.pdf -o outfile.pcap\n"\
+				"\t\t\tfile2pcap -mi -s 1.2.3.4 -d 5.6.7.8 -S src@example.com -D dst@example.com alware.pdf";
 
 	printf("%s\n", helptext);
 	printf("%s\n", usage);

--- a/file2pcap.h
+++ b/file2pcap.h
@@ -44,6 +44,8 @@ struct handover {
 	char protoEther[2];
 	char srcFile[200];
 	char dstFile[200];
+	char srcEmail[255];
+	char dstEmail[255];
 	char toEther[15];
 	char fromEther[15];
 	FILE *inFile;

--- a/imap.c
+++ b/imap.c
@@ -20,7 +20,8 @@
 
 int imapRequest(struct handover *ho) {
 	char *badjoke;
-        char serverImapHeader[] =  "* OK [CAPABILITY IMAP4REV1 I18NLEVEL=1 LITERAL+ SASL-IR LOGIN-REFERRALS] [10.10.5.140] \r\nIMAP4rev1 2007e.404 at Tue, 9 Nov 2010 15:13:41 +0000 (WET)\r\n";
+	char serverMailHeader[5000];
+    char serverImapHeader[] =  "* OK [CAPABILITY IMAP4REV1 I18NLEVEL=1 LITERAL+ SASL-IR LOGIN-REFERRALS] [10.10.5.140] \r\nIMAP4rev1 2007e.404 at Tue, 9 Nov 2010 15:13:41 +0000 (WET)\r\n";
 	char clientUserPass[] = "A01 LOGIN user secret\r\n";
 	char serverOk[] = 	"A01 OK [CAPABILITY IMAP4REV1 I18NLEVEL=1 LITERAL+ IDLE UIDPLUS NAMESPACE CHILDREN MAILBOX-REFERRALS "\
 				"BINARY UNSELECT ESEARCH WITHIN SCAN SORT THREAD=REFERENCES THREAD=ORDEREDSUBJECT MULTIAPPEND] User user authenticated\r\n";
@@ -33,8 +34,9 @@ int imapRequest(struct handover *ho) {
 	char clientFetch[] = "A04 UID FETCH 1 (UID RFC822.SIZE BODY.PEEK[]<0.65536>)\r\n";
 	char serverFetch[] = "* 1 FETCH (UID 1 RFC822.SIZE 117982 BODY[]<0> {65536}\r\n";
 
+/*
 	char serverMailHeader[] = "Return-Path: <" SRC_EMAIL ">\r\n"\
-		"Delivered-To: " MAILHOST "-"DST_EMAIL "\r\n"\
+		"Delivered-To: " MAILHOST "-" DST_EMAIL "\r\n"\
 		"Received: (qmail 12912 invoked by uid 89); 26 May 2014 10:14:00 -0000\r\n"\
 		"Received: by simscan 1.4.0 ppid: 12861, pid: 12896, t: 0.8526s\r\n"\
 		"         scanners: clamav: 0.95.2/m:51/d:9604\r\n"\
@@ -51,6 +53,8 @@ int imapRequest(struct handover *ho) {
 		"Importance: normal\r\n"\
 		"Sensitivity: Normal\r\n"\
 		"X-Priority: 3\r\n\r\n";
+*/
+	snprintf(serverMailHeader, sizeof(serverMailHeader)-1, IMAPSERVERMAILHEADER, ho->srcEmail, ho->dstEmail, MAILHOST);
 
 	char serverMailText[] = "--refeics-138facf0-915a-4457-8ff5-a6982ea42135\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n";
 	char serverAttachmentHeader[] = "--refeics-138facf0-915a-4457-8ff5-a6982ea42135\r\nContent-Type: application/octet-stream\r\nContent-Disposition: attachment; filename=";

--- a/imap.h
+++ b/imap.h
@@ -3,3 +3,21 @@ int imapRequest(struct handover *ho);
 //char *base64_encode(char *data, size_t input_length, size_t *output_length);
 int imapTransferFile(struct handover *ho);
 
+#define IMAPSERVERMAILHEADER "Return-Path: <%1$s>\r\n"\
+		"Delivered-To: %3$s-%2$s\r\n"\
+		"Received: (qmail 12912 invoked by uid 89); 26 May 2014 10:14:00 -0000\r\n"\
+		"Received: by simscan 1.4.0 ppid: 12861, pid: 12896, t: 0.8526s\r\n"\
+		"         scanners: clamav: 0.95.2/m:51/d:9604\r\n"\
+		"Received: from unknown (HELO %3$s) (bmE=@1.2.3.4) by %3$s with (DHE-RSA-AES256-SHA encrypted) SMTP; 26 May 2014 10:14:00 -0000\r\n"\
+		"Received: from [12.21.12.21] by %3$s with HTTP; Mon, 26 May 2014 12:13:56 +0200\r\n"\
+		"MIME-Version: 1.0\r\n"\
+		"Message-ID: <trinity-5335e8d2-aa96-4eb1-80cc-e9657b28fc65-1401099236666@%3$s>\r\n"\
+		"From: <%1$s>\r\n"\
+		"To: %2$s\r\n"\
+		"Subject: file2pcap\r\n"\
+		"Content-Type: multipart/mixed;\r\n"\
+		" boundary=refeics-138facf0-915a-4457-8ff5-a6982ea42135\r\n"\
+		"Date: Mon, 26 May 2014 12:13:56 +0000\r\n"\
+		"Importance: normal\r\n"\
+		"Sensitivity: Normal\r\n"\
+		"X-Priority: 3\r\n\r\n"

--- a/pop3.c
+++ b/pop3.c
@@ -23,7 +23,8 @@
 int pop3Request(struct handover *ho) {
 	char buffer[5000];
 	char *badjoke=NULL;
-        char serverPop3Header[] =  "+OK Microsoft Exchange Server 2003 POP3 server version 6.5.7638.1 (server.testing) ready.\r\n";
+	char serverMailHeader[5000];
+    char serverPop3Header[] =  "+OK Microsoft Exchange Server 2003 POP3 server version 6.5.7638.1 (server.testing) ready.\r\n";
 	char clientUser[] = "USER user\r\n";
 	char serverOk[] = "+OK\r\n";
 	char clientPass[] = "PASS secret\r\n";
@@ -35,6 +36,7 @@ int pop3Request(struct handover *ho) {
 	char clientAttachmentSeparator[] = "--------------070104010108080805080502--\r\n.\r\n";
 	char serverClose[] = "+OK Microsoft Exchange Server 2003 POP3 server version 6.5.7638.1 signing off.\r\n";
 
+/*
 	char serverMailHeader[] = "Received: from " SRC_EMAIL " by (1.2.3.4:25) via " MAILHOST "\r\n"\
 		" (199.91.174.187:56258) with [" MAILHOST " SMTP Server] id 1405730148303.WH100\r\n"\
 		"  for " DST_EMAIL "; Fri, 23 May 2014 01:48:56 -0200\r\n"\
@@ -47,6 +49,9 @@ int pop3Request(struct handover *ho) {
 		"Subject: file2pcap\r\n"\
 		"Content-Type: multipart/mixed;\r\n"\
 		" boundary=\"------------070104010108080805080502\"\r\n\r\n";
+*/
+	snprintf(serverMailHeader, sizeof(serverMailHeader)-1, POPSERVERMAILHEADER, ho->srcEmail, ho->dstEmail, MAILHOST);
+
 	char serverMailBody[] = 		"This is a multi-part message in MIME format.\r\n"\
 						"--------------070104010108080805080502\r\n"\
 						"Content-Type: text/plain; charset=ISO-8859-2\r\n"\
@@ -80,7 +85,6 @@ int pop3Request(struct handover *ho) {
 	//FIXME - build 'OK' buffer with message size to send
 	snprintf(buffer, sizeof(buffer)-1, "+OK %d octets\r\n", 10000);	//FIXME
 	tcpSendString(ho, buffer, FROM_SERVER);
-
 	tcpSendString(ho, serverMailHeader, FROM_SERVER);
 	tcpSendString(ho, serverMailBody, FROM_SERVER);
 

--- a/pop3.h
+++ b/pop3.h
@@ -3,3 +3,15 @@ int pop3Request(struct handover *ho);
 //char *base64_encode(char *data, size_t input_length, size_t *output_length);
 int pop3TransferFile(struct handover *ho);
 
+#define POPSERVERMAILHEADER "Received: from %1$s by (1.2.3.4:25) via %3$s\r\n"\
+		" (199.91.174.187:56258) with [%3$s SMTP Server] id 1405730148303.WH100\r\n"\
+		"  for %2$s; Fri, 23 May 2014 01:48:56 -0200\r\n"\
+		"Message-ID: <537F197F.1020309@%3$s>\r\n"\
+		"Date: Fri, 23 May 2014 11:48:47 +0500\r\n"\
+		"From: <%1$s>\r\n"\
+		"User-Agent: Mozilla/5.0 (X11; Linux i686; rv:24.0) Gecko/20100101 Thunderbird/24.5.0\r\n"\
+		"MIME-Version: 1.0\r\n"\
+		"To: %2$s\r\n"\
+		"Subject: file2pcap\r\n"\
+		"Content-Type: multipart/mixed;\r\n"\
+		" boundary=\"------------070104010108080805080502\"\r\n\r\n"

--- a/smtp.c
+++ b/smtp.c
@@ -24,23 +24,34 @@
 int smtpRequest(struct handover *ho) {
 	char buffer[5000];
 	char *badjoke = NULL;
-        char serverSmtpHeader[] =  "220 " MAILHOST " ESMTP Sendmail 8.14.5/8.14.5; Thu, 22 May 2014 12:12:12 GMT\r\n";
+	char clientMailFrom[500], serverSenderOk[500], clientReceiptTo[500], serverRecipientOk[500], clientMailBody[1000];
+
+    char serverSmtpHeader[] =  "220 " MAILHOST " ESMTP Sendmail 8.14.5/8.14.5; Thu, 22 May 2014 12:12:12 GMT\r\n";
 	char clientEhlo[] = "EHLO user\r\n";
 	char serverOptions1[] = "250-" MAILHOST " Hello user." MAILHOST " [10.1.2.3], pleased to meet you\r\n";
 	char serverOptions2[] = "250-ENHANCEDSTATUSCODES\r\n250-PIPELINING\r\n250-EXPN\r\n250-VERB\r\n250-8BITMIME\r\n250-SIZE 32000000\r\n250-DSN\r\n250-ETRN\r\n250-STARTTLS\r\n250-DELIVERBY\r\n250 HELP\r\n";
-	char clientMailFrom[] = "MAIL FROM:<" SRC_EMAIL "> SIZE="; //FIXME - size is dynamic
-	char serverSenderOk[] = "250 2.1.0 <" SRC_EMAIL ">... Sender ok\r\n";
-	char clientReceiptTo[] = "RCPT TO:<" DST_EMAIL ">\r\n";
-	char serverRecipientOk[] = "250 2.1.5 <" DST_EMAIL ">... Recipient ok\r\n";
+
+	//char clientMailFrom[] = "MAIL FROM:<" ho.srcEmail "> SIZE="; //FIXME - size is dynamic
+	snprintf(clientMailFrom, sizeof(clientMailFrom)-1, CLIENTMAILFROM, ho->srcEmail);
+
+	//char serverSenderOk[] = "250 2.1.0 <" ho.srcEmail ">... Sender ok\r\n";
+	snprintf(serverSenderOk, sizeof(serverSenderOk)-1, SERVERSENDEROK, ho->srcEmail);
+
+	//char clientReceiptTo[] = "RCPT TO:<" ho.dstEmail ">\r\n";
+	snprintf(clientReceiptTo, sizeof(clientReceiptTo)-1, CLIENTRECEIPTTO, ho->dstEmail);
+
+	//char serverRecipientOk[] = "250 2.1.5 <" ho.dstEmail ">... Recipient ok\r\n";
+	snprintf(serverRecipientOk, sizeof(serverRecipientOk)-1, SERVERRECIPIENTOK, ho->dstEmail);
+
 	char clientData[] = "DATA\r\n";
 	char serverEnterMail[] = "354 Enter mail, end with \".\" on a line by itself\r\n";
 
-	char clientMailBody[] = "Message-ID: <537DC502.5080409@" MAILHOST ">\r\n"\
+/*	char clientMailBody[] = "Message-ID: <537DC502.5080409@" MAILHOST ">\r\n"\
 		"Date: Thu, 22 May 2014 11:36:02 +0200\r\n"\
-		"From: <" SRC_EMAIL ">\r\n"\
+		"From: <" MAILHOST ">\r\n"\
 		"User-Agent: Mozilla/5.0 (X11; Linux i686; rv:24.0) Gecko/20100101 Thunderbird/24.5.0\r\n"\
 		"MIME-Version: 1.0\r\n"\
-		"To: <" DST_EMAIL ">\r\n"\
+		"To: <" MAILHOST ">\r\n"\
 		"Subject: file2pcap from Martin Zeiser\r\n"\
 		"X-Enigmail-Version: 1.6\r\n"\
 		"Content-Type: multipart/mixed;\r\n"\
@@ -49,6 +60,9 @@ int smtpRequest(struct handover *ho) {
 		"--------------020106020307040709020108\r\n"\
 		"Content-Type: text/plain; charset=ISO-8859-1\r\n"\
 		"Content-Transfer-Encoding: 7bit\r\n\r\n";
+*/
+	snprintf(clientMailBody, sizeof(clientMailBody)-1, CLIENTMAILBODY, ho->srcEmail, ho->dstEmail);
+
 	char clientAttachmentSeparator1[] = "--------------020106020307040709020108\r\n";
 	char clientAttachment2b64[] = "\r\nContent-Transfer-Encoding: base64\r\nContent-Disposition: attachment; filename=\"";
 	char clientAttachment2qp[] = "\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Disposition: attachment; filename=\"";
@@ -57,10 +71,6 @@ int smtpRequest(struct handover *ho) {
 	char serverMessageAccepted[] = "250 2.0.0 s4M9a2xl017623 Message accepted for delivery\r\n";
 	char clientQuit[] = "QUIT\r\n";
 	char serverClose[] = "221 2.0.0 " MAILHOST " closing connection\r\n";
-
-
-
-
 
 	tcpSendString(ho, serverSmtpHeader, FROM_SERVER);
 	tcpSendString(ho, clientEhlo, TO_SERVER);

--- a/smtp.h
+++ b/smtp.h
@@ -1,3 +1,21 @@
+#define CLIENTMAILFROM "MAIL FROM:<%s> SIZE=" //FIXME - size is dynamic
+#define SERVERSENDEROK "250 2.1.0 <%s>... Sender ok\r\n"
+#define CLIENTRECEIPTTO "RCPT TO:<%s>\r\n"
+#define SERVERRECIPIENTOK "250 2.1.5 <%s>... Recipient ok\r\n"
+#define CLIENTMAILBODY "Message-ID: <537DC502.5080409@" MAILHOST ">\r\n"\
+		"Date: Thu, 22 May 2014 11:36:02 +0200\r\n"\
+		"From: <%s>\r\n"\
+		"User-Agent: Mozilla/5.0 (X11; Linux i686; rv:24.0) Gecko/20100101 Thunderbird/24.5.0\r\n"\
+		"MIME-Version: 1.0\r\n"\
+		"To: <%s>\r\n"\
+		"Subject: file2pcap from Martin Zeiser\r\n"\
+		"X-Enigmail-Version: 1.6\r\n"\
+		"Content-Type: multipart/mixed;\r\n"\
+		" boundary=\"------------020106020307040709020108\"\r\n\r\n"\
+		"This is a multi-part message in MIME format.\r\n"\
+		"--------------020106020307040709020108\r\n"\
+		"Content-Type: text/plain; charset=ISO-8859-1\r\n"\
+		"Content-Transfer-Encoding: 7bit\r\n\r\n"
 
 int smtpRequest(struct handover *ho);
 //char *base64_encode(char *data, size_t input_length, size_t *output_length);


### PR DESCRIPTION
This branch adds command line options for specifying src/dst IP and email addresses. Also adds "long" options for existing options:

-e, --encoding
-m, --mode
-o, --outfile
-p, --port
-6
-d, --dstip
-s, --srcip
-D, --dstemail
-S, --srcemail